### PR TITLE
Fix incorrect number of logger parameters

### DIFF
--- a/src/Worker.Logic/MessageProcessors/TaskStateMessageProcessor.cs
+++ b/src/Worker.Logic/MessageProcessors/TaskStateMessageProcessor.cs
@@ -44,7 +44,12 @@ namespace NuGet.Insights.Worker
                 }
                 else
                 {
-                    _logger.LogError("Attempt {AttemptCount}: no task state for {StorageSuffix}, {PartitionKey}, {RowKey} was found. Giving up.", message.AttemptCount);
+                    _logger.LogError(
+                        "Attempt {AttemptCount}: no task state for {StorageSuffix}, {PartitionKey}, {RowKey} was found. Giving up.",
+                        message.AttemptCount,
+                        message.TaskStateKey.StorageSuffix,
+                        message.TaskStateKey.PartitionKey,
+                        message.TaskStateKey.RowKey);
                 }
 
                 return;


### PR DESCRIPTION
Not detected at build-time due to https://github.com/dotnet/roslyn-analyzers/issues/5738