### PR TITLE
Use managed identities for Azure Table Storage access

### DIFF
--- a/deploy/scripts/Invoke-Prepare.ps1
+++ b/deploy/scripts/Invoke-Prepare.ps1
@@ -43,7 +43,6 @@ New-Deployment `
     -ResourceGroupName $ResourceSettings.ResourceGroupName `
     -KeyVaultName $ResourceSettings.KeyVaultName `
     -StorageAccountName $ResourceSettings.StorageAccountName `
-    -TableSasDefinitionName $ResourceSettings.TableSasDefinitionName `
     -AutoRegenerateKey:$ResourceSettings.AutoRegenerateKey `
     -SasValidityPeriod $ResourceSettings.SasValidityPeriod
 

--- a/deploy/scripts/NuGet.Insights.psm1
+++ b/deploy/scripts/NuGet.Insights.psm1
@@ -77,9 +77,6 @@ class ResourceSettings {
     [string]$KeyVaultName
     
     [ValidateNotNullOrEmpty()]
-    [string]$TableSasDefinitionName
-    
-    [ValidateNotNullOrEmpty()]
     [string]$DeploymentContainerName
     
     [ValidateNotNullOrEmpty()]
@@ -165,7 +162,6 @@ class ResourceSettings {
         $this.ExistingWebsitePlanId = $d.ExistingWebsitePlanId
 
         # Static settings
-        $this.TableSasDefinitionName = "TableFullAccessSas"
         $this.DeploymentContainerName = "deployment"
         $this.LeaseContainerName = "leases"
         $this.SasValidityPeriod = New-TimeSpan -Days 6
@@ -385,7 +381,6 @@ function New-MainParameters($ResourceSettings, $WebsiteZipUrl, $WorkerZipUrl) {
         keyVaultName                  = $ResourceSettings.KeyVaultName;
         deploymentContainerName       = $ResourceSettings.DeploymentContainerName;
         leaseContainerName            = $ResourceSettings.LeaseContainerName;
-        tableSasDefinitionName        = $ResourceSettings.TableSasDefinitionName;
         websiteName                   = $ResourceSettings.WebsiteName;
         websiteAadClientId            = $ResourceSettings.WebsiteAadAppClientId;
         websiteConfig                 = @($ResourceSettings.WebsiteConfig | ConvertTo-FlatConfig | ConvertTo-NameValuePairs);

--- a/deploy/scripts/Set-KeyVaultManagedStorage.ps1
+++ b/deploy/scripts/Set-KeyVaultManagedStorage.ps1
@@ -10,9 +10,6 @@ param (
     [string]$StorageAccountName,
     
     [Parameter(Mandatory = $true)]
-    [string]$TableSasDefinitionName,
-    
-    [Parameter(Mandatory = $true)]
     [switch]$AutoRegenerateKey,
 
     [Parameter(Mandatory = $true)]
@@ -125,28 +122,6 @@ if (!$matchingStorage) {
         }
     }
 }
-
-Write-Status "Generating a template SAS for '$TableSasDefinitionName'..."
-$storageContext = New-AzStorageContext `
-    -StorageAccountName $StorageAccountName `
-    -Protocol Https `
-    -StorageAccountKey $storageEmulatorKey
-$tableSasTemplate = New-AzStorageAccountSASToken `
-    -ExpiryTime (Get-Date "2010-01-01Z").ToUniversalTime() `
-    -Permission "rwdlacu" `
-    -ResourceType Service, Container, Object `
-    -Service Table `
-    -Protocol HttpsOnly `
-    -Context $storageContext
-    
-Write-Status "Creating SAS definition '$TableSasDefinitionName'..."
-Set-AzKeyVaultManagedStorageSasDefinition `
-    -VaultName $KeyVaultName `
-    -AccountName $StorageAccountName `
-    -Name $TableSasDefinitionName `
-    -ValidityPeriod $SasValidityPeriod `
-    -SasType 'account' `
-    -TemplateUri $tableSasTemplate | Out-Default
 
 Write-Status "Removing Key Vault role assignment for '$($currentUser.userPrincipalName)' (object ID $($currentUser.id))..."
 $attempt = 0

--- a/deploy/storage-and-kv.bicep
+++ b/deploy/storage-and-kv.bicep
@@ -73,17 +73,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' = {
   }
 }
 
-// Gives permissions to use secrets
-resource keyVaultReadSecretPermissions 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for identity in identities: {
-  name: !empty(identities) ? guid('AppsCanUseKeyVaultSecrets-${identity.tenantId}-${identity.objectId}') : guid('placeholderA')
-  scope: keyVault
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
-    principalId: identity.objectId
-    principalType: 'ServicePrincipal'
-  }
-}]
-
 // Gives permissions to read certificates
 resource keyVaultReadPermissions 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for identity in identities: {
   name: !empty(identities) ? guid('AppsCanReadKeyVault-${identity.tenantId}-${identity.objectId}') : guid('placeholderB')

--- a/src/Logic/Logic.csproj
+++ b/src/Logic/Logic.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.16.1" />
-    <PackageReference Include="Azure.Data.Tables" Version="12.3.0" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.5.0" />
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.8.0" />
     <PackageReference Include="Knapcode.MiniZip" Version="0.17.0" />

--- a/src/Logic/NuGetInsightsSettings.cs
+++ b/src/Logic/NuGetInsightsSettings.cs
@@ -21,8 +21,6 @@ namespace NuGet.Insights
             OwnersV2Url = null;
             StorageAccountName = null;
             StorageBlobReadSharedAccessSignature = null;
-            KeyVaultName = null;
-            TableSharedAccessSignatureSecretName = null;
             StorageConnectionString = StorageUtility.EmulatorConnectionString;
             LeaseContainerName = "leases";
             PackageArchiveTableName = "packagearchives";
@@ -51,8 +49,6 @@ namespace NuGet.Insights
 
         public string StorageAccountName { get; set; }
         public string StorageBlobReadSharedAccessSignature { get; set; }
-        public string KeyVaultName { get; set; }
-        public string TableSharedAccessSignatureSecretName { get; set; }
         public string StorageConnectionString { get; set; }
 
         public string LeaseContainerName { get; set; }

--- a/src/Logic/Support/HashOutput.cs
+++ b/src/Logic/Support/HashOutput.cs
@@ -1,13 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.Insights
 {
     public class HashOutput
     {
-        public byte[] MD5 { get; internal set; }
-        public byte[] SHA1 { get; internal set; }
-        public byte[] SHA256 { get; internal set; }
-        public byte[] SHA512 { get; internal set; }
+        public byte[] MD5 { get; set; }
+        public byte[] SHA1 { get; set; }
+        public byte[] SHA256 { get; set; }
+        public byte[] SHA512 { get; set; }
     }
 }


### PR DESCRIPTION
This feature is in preview but appears to work great!

Manual clean-up required:
- Remove `Key Vault Secrets User` role assignments from the KeyVault
- Remove the table SAS definition available in the storage account


