### PR TITLE
Skip a specific test on Azurite due to no request body size limit

### DIFF
--- a/test/Logic.Test/TestSupport/StorageType.cs
+++ b/test/Logic.Test/TestSupport/StorageType.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Insights
+{
+    [Flags]
+    public enum StorageType
+    {
+        Azure = 1 << 0,
+        LegacyEmulator = 1 << 1,
+        Azurite = 1 << 2,
+    }
+}

--- a/test/Logic.Test/TestSupport/StorageTypeFactAttribute.cs
+++ b/test/Logic.Test/TestSupport/StorageTypeFactAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGet.Insights
+{
+    public class StorageTypeFactAttribute : FactAttribute
+    {
+        public StorageTypeFactAttribute(StorageType storageType)
+        {
+            if (!storageType.HasFlag(TestSettings.StorageType))
+            {
+                Skip = $"This Fact is skipped because the current storage type is '{TestSettings.StorageType}', not '{storageType}'.";
+            }
+        }
+    }
+}

--- a/test/Logic.Test/WideEntities/WideEntityServiceTest.cs
+++ b/test/Logic.Test/WideEntities/WideEntityServiceTest.cs
@@ -72,7 +72,10 @@ namespace NuGet.Insights.WideEntities
                 Assert.Empty(retrieved);
             }
 
-            [Fact]
+            /// <summary>
+            /// This test fails on Azurite due to https://github.com/Azure/Azurite/issues/1319.
+            /// </summary>
+            [StorageTypeFact(StorageType.Azure | StorageType.LegacyEmulator)]
             public async Task FailsWhenCannotSplitBatch()
             {
                 // Arrange


### PR DESCRIPTION
This should work around the last blocker mentioned here: https://github.com/NuGet/Insights/issues/30.

Once the next Azurite release (3.17.0) comes out, we can test full Azurite integration.