### PR TITLE
Use template expressions instead of job matrix

### DIFF
--- a/.pipelines/Retail.PullRequest.yml
+++ b/.pipelines/Retail.PullRequest.yml
@@ -1,10 +1,19 @@
+parameters:
+- name: rids
+  displayName: The runtime identifiers to publish for (implies build agent OS)
+  type: object
+  default:
+    - linux-x64
+    - osx-x64
+    - win-x64
+
 stages:
-- stage: MarkdownLinkCheck
+- stage: markdown_link_check
   dependsOn: []
   jobs:
-  - job: 
+  - job: scan
     pool:
-      vmImage: "windows-latest"
+      vmImage: windows-latest
     steps:
     - script: npm install -g markdown-link-check@3.10.0
       displayName: "Install markdown-link-check"
@@ -15,116 +24,104 @@ stages:
         script: 'Get-ChildItem $(Build.SourcesDirectory)/*.md -Recurse | % { markdown-link-check $_ --config $(Build.SourcesDirectory)/markdown-link-check.config.json }'
         failOnStderr: true
 
-- stage: Build
+- stage: build
   dependsOn: []
   jobs:
-  - job:
-    strategy:
-      matrix:
-        Linux:
-          ImageName: "ubuntu-latest"
-          DropName: "drop-linux"
-          PublishRuntimeIdentifier: "linux-x64"
-        macOS:
-          ImageName: "macos-latest"
-          DropName: "drop-macos"
-          PublishRuntimeIdentifier: "osx-x64"
-        Windows:
-          ImageName: "windows-latest"
-          DropName: "drop-windows"
-          PublishRuntimeIdentifier: "win-x64"
+  - ${{ each rid in parameters.rids }}:
+    - job: ${{ replace(rid, '-', '_') }}
+    
+      pool:
+        ${{ if startsWith(rid, 'linux-') }}:
+          vmImage: ubuntu-latest
+        ${{ elseif startsWith(rid, 'osx-') }}:
+          vmImage: macos-latest
+        ${{ elseif startsWith(rid, 'win-') }}:
+          vmImage: windows-latest
 
-    pool:
-      vmImage: $(ImageName)
+      variables:
+        - group: NuGet.Insights
+        - name: BuildConfiguration
+          value: Release
+        - name: BuildSolution
+          value: "$(Build.SourcesDirectory)/NuGet.Insights.sln"
+        - name: OutputDirectory
+          value: "$(Build.SourcesDirectory)/artifacts"
 
-    variables:
-      - group: NuGet.Insights
-      - name: BuildConfiguration
-        value: Release
-      - name: BuildSolution
-        value: "$(Build.SourcesDirectory)/NuGet.Insights.sln"
-      - name: OutputDirectory
-        value: "$(Build.SourcesDirectory)/artifacts"
+      steps:
+        - task: UseDotNet@2
+          displayName: "Install .NET SDK from global.json"
+          inputs:
+            packageType: sdk
+            useGlobalJson: true
+            performMultiLevelLookup: true
+        
 
-    steps:
-      - task: UseDotNet@2
-        displayName: "Install .NET SDK 3.1.x"
-        inputs:
-          packageType: sdk
-          version: 3.1.x
+        - task: DotNetCoreCLI@2
+          displayName: "Restore"
+          inputs:
+            command: "restore"
+            feedsToUse: "config"
+            nugetConfigPath: "$(Build.SourcesDirectory)/NuGet.config"
+            projects: $(BuildSolution)
 
-      - task: UseDotNet@2
-        displayName: "Install .NET SDK from global.json"
-        inputs:
-          packageType: sdk
-          useGlobalJson: true
-          performMultiLevelLookup: true
+        - task: DotNetCoreCLI@2
+          displayName: "Build"
+          inputs:
+            command: "custom"
+            projects: $(BuildSolution)
+            custom: "build"
+            arguments: "--no-restore --configuration $(BuildConfiguration)"
 
-      - task: DotNetCoreCLI@2
-        displayName: "Restore"
-        inputs:
-          command: "restore"
-          feedsToUse: "config"
-          nugetConfigPath: "$(Build.SourcesDirectory)/NuGet.config"
-          projects: $(BuildSolution)
+        - task: DotNetCoreCLI@2
+          displayName: "Run tests"
+          inputs:
+            command: "test"
+            arguments: '--no-build --no-restore --configuration $(BuildConfiguration) --logger trx --blame-hang-timeout 10m --collect "Code coverage" --results-directory $(OutputDirectory)/TestResults/'
+            publishTestResults: false
+          env:
+            NUGETINSIGHTS_STORAGEACCOUNTNAME: nugetinsightstests
+            NUGETINSIGHTS_STORAGESAS: $(nugetinsightstests-BlobQueueTableFullAccessSas)
+            NUGETINSIGHTS_STORAGEBLOBREADSAS: $(nugetinsightstests-BlobReadSas)
 
-      - task: DotNetCoreCLI@2
-        displayName: "Build"
-        inputs:
-          command: "custom"
-          projects: $(BuildSolution)
-          custom: "build"
-          arguments: "--no-restore --configuration $(BuildConfiguration)"
+        - task: PublishTestResults@2
+          displayName: "Publish test results"
+          inputs:
+            testResultsFormat: VSTest
+            testResultsFiles: "$(OutputDirectory)/TestResults/**/*.trx"
+            failTaskOnFailedTests: true
 
-      - task: DotNetCoreCLI@2
-        displayName: "Run tests"
-        inputs:
-          command: "test"
-          arguments: '--no-build --no-restore --configuration $(BuildConfiguration) --logger trx --blame-hang-timeout 10m --collect "Code coverage" --results-directory $(OutputDirectory)/TestResults/'
-          publishTestResults: false
-        env:
-          NUGETINSIGHTS_STORAGEACCOUNTNAME: nugetinsightstests
-          NUGETINSIGHTS_STORAGESAS: $(nugetinsightstests-BlobQueueTableFullAccessSas)
-          NUGETINSIGHTS_STORAGEBLOBREADSAS: $(nugetinsightstests-BlobReadSas)
+        - task: PowerShell@2
+          displayName: "Checking for Forks changes"
+          inputs:
+            targetType: "filePath"
+            filePath: $(Build.SourcesDirectory)/src/Forks/download.ps1
 
-      - task: PublishTestResults@2
-        displayName: "Publish test results"
-        inputs:
-          testResultsFormat: VSTest
-          testResultsFiles: "$(OutputDirectory)/TestResults/**/*.trx"
-          failTaskOnFailedTests: true
+        - task: DotNetCoreCLI@2
+          displayName: "Publish projects to ZIP"
+          inputs:
+            command: publish
+            publishWebProjects: false
+            projects: |
+              $(Build.SourcesDirectory)/src/Website/Website.csproj
+              $(Build.SourcesDirectory)/src/Worker/Worker.csproj
+            arguments: "--configuration $(BuildConfiguration) --runtime ${{ rid }} --self-contained false"
+            zipAfterPublish: false
 
-      - task: PowerShell@2
-        displayName: "Checking for Forks changes"
-        inputs:
-          targetType: "filePath"
-          filePath: $(Build.SourcesDirectory)/src/Forks/download.ps1
 
-      - task: DotNetCoreCLI@2
-        displayName: "Publish projects to ZIP"
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: |
-            $(Build.SourcesDirectory)/src/Website/Website.csproj
-            $(Build.SourcesDirectory)/src/Worker/Worker.csproj
-          arguments: "--configuration $(BuildConfiguration) --runtime $(PublishRuntimeIdentifier) --self-contained false"
-          zipAfterPublish: false
+        - task: PowerShell@2
+          displayName: "Generate Ev2 files"
+          inputs:
+            targetType: "filePath"
+            filePath: $(Build.SourcesDirectory)/deploy/build-ev2.ps1
+            arguments: >
+              -ConfigNames ev2-dev-usnc
+              -BuildVersion $(Build.BuildNumber)
+              -WebsiteZipPath $(OutputDirectory)/deploy/Website.zip
+              -WorkerZipPath $(OutputDirectory)/deploy/Worker.zip
 
-      - task: PowerShell@2
-        displayName: "Generate Ev2 files"
-        inputs:
-          targetType: "filePath"
-          filePath: $(Build.SourcesDirectory)/deploy/build-ev2.ps1
-          arguments: >
-            -ConfigNames ev2-dev-usnc
-            -BuildVersion $(Build.BuildNumber)
-            -WebsiteZipPath $(OutputDirectory)/deploy/Website.zip
-            -WorkerZipPath $(OutputDirectory)/deploy/Worker.zip
-
-      - task: PublishBuildArtifacts@1
-        displayName: "Publish build artifacts"
-        inputs:
-          pathToPublish: $(OutputDirectory)/ExpressV2
-          artifactName: $(DropName)
-          Parallel: true
+        - task: PublishBuildArtifacts@1
+          displayName: "Publish build artifacts"
+          inputs:
+            pathToPublish: $(OutputDirectory)/ExpressV2
+            artifactName: drop-${{ rid }}
+            Parallel: true


### PR DESCRIPTION
This allows more flexibility like changing the pool, image, or demands per platform.