### PR TITLE
Add transient case in lease result (#71)

### DIFF
--- a/src/Logic/Leasing/BaseLeaseResult.cs
+++ b/src/Logic/Leasing/BaseLeaseResult.cs
@@ -8,7 +8,7 @@ namespace NuGet.Insights
     public class BaseLeaseResult<T>
     {
         public const string NotAcquiredAtAll = "The provided lease was not acquired in the first place.";
-        public const string AcquiredBySomeoneElse = "The lease has been acquired by someone else.";
+        public const string AcquiredBySomeoneElse = "The lease has been acquired by someone else, or transient errors happened.";
         public const string NotAvailable = "The lease is not available yet.";
 
         protected BaseLeaseResult(T lease, bool acquired)


### PR DESCRIPTION
I only add the transient error possibility to the `AcquiredBySomeoneElse`. I hope this can help the diagnosability. 