### PR TITLE
Fix solution build in VS by adding package source mappings for BenchmarkDotNet

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -23,6 +23,8 @@
       <package pattern="AppInsights.WindowsDesktop" />
       <package pattern="Autofac" />
       <package pattern="Azure.*" />
+      <package pattern="BenchmarkDotNet" />
+      <package pattern="BenchmarkDotNet.Annotations" />
       <package pattern="Ben.StringIntern" />
       <package pattern="BuildBundlerMinifier" />
       <package pattern="Castle.Core" />
@@ -52,6 +54,7 @@
       <package pattern="NuGet.*" />
       <package pattern="PeNet.Asn1" />
       <package pattern="PeNet" />
+      <package pattern="Perfolizer" />
       <package pattern="Polly.Extensions.Http" />
       <package pattern="Polly" />
       <package pattern="protobuf-net" />


### PR DESCRIPTION
I found this issue while trying to build the solution in Visual Studio.

> Unable to resolve 'BenchmarkDotNet (>= 0.14.0)' for 'net8.0'. PackageSourceMapping is enabled, the following source(s) were not considered: AzureFunctions@internalrelease, AzureFunctionsPreRelease, AzureFunctionsRelease, AzureFunctionsTempStaging, C:\Program Files\dotnet\library-packs, dotnet-tools, Microsoft.Azure.Functions.PowerShellWorker, NuGet.org, NuGetPackageExplorer.